### PR TITLE
fix -Wformat

### DIFF
--- a/sscanApp/src/saveData.c
+++ b/sscanApp/src/saveData.c
@@ -849,7 +849,7 @@ void saveData_Info() {
 		printf("  links:");
 		cur= scan;
 		while (cur) {
-			printf(cur->name);
+			printf("%s", cur->name);
 			cur= cur->nxt;
 			if (cur) printf("->");
 		}


### PR DESCRIPTION
Fix a potential issue with improper use of printf().  Triggers gcc "-Wformat -Werror=format-security" (cf. https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#Warning-Options)