### PR TITLE
Move default saveData.req from xxx to sscan

### DIFF
--- a/sscanApp/Db/saveData.req
+++ b/sscanApp/Db/saveData.req
@@ -1,0 +1,40 @@
+[prefix]
+$(P)
+
+[status]
+$(P)saveData_status
+
+[message]
+$(P)saveData_message
+
+[filename]
+$(P)saveData_fileName
+
+[counter]	# scan counter
+$(P)saveData_scanNumber
+
+[fileSystem] # scan file system
+$(P)saveData_fileSystem
+
+[subdir]	# scan file subdirectory
+$(P)saveData_subDir
+
+[basename]	# scan file base name
+$(P)saveData_baseName
+
+[fullPathName]
+$(P)saveData_fullPathName
+
+[realTime1D] # if nonzero, write 1D data as it comes in
+$(P)saveData_realTime1D
+
+[scanRecord]	# specify scan records to be monitored
+$(P)scanH
+$(P)scan1
+$(P)scan2
+$(P)scan3
+$(P)scan4
+
+[extraPV]
+$(P)saveData_comment1
+$(P)saveData_comment2


### PR DESCRIPTION
The sscan.iocsh script loads saveData.req by default. We should have a default copy to be found in the db directory and if the user wants to customize, they can just put a copy in their IOC and the new req file will be found first due to the IOC's directories being higher in the requestfile_path search.