### PR TITLE
Replace READONLY with const

### DIFF
--- a/sscanApp/src/saveData.c
+++ b/sscanApp/src/saveData.c
@@ -1844,7 +1844,7 @@ LOCAL void extraValCallback(struct event_handler_args eha)
 	PV_NODE * pnode = eha.usr;
 	long type = eha.type;
 	long count = eha.count;
-	READONLY DBR_VAL * pval = eha.dbr;
+	const DBR_VAL * pval = eha.dbr;
 	char *string;
 
 	size_t size=0;
@@ -1891,7 +1891,7 @@ LOCAL void extraValCallback(struct event_handler_args eha)
 LOCAL void extraDescCallback(struct event_handler_args eha)
 {
 	PV_NODE * pnode = eha.usr;
-	READONLY DBR_VAL * pval = eha.dbr;
+	const DBR_VAL * pval = eha.dbr;
 
 	epicsMutexLock(pnode->lock);
 

--- a/sscanApp/src/saveData_writeXDR.c
+++ b/sscanApp/src/saveData_writeXDR.c
@@ -208,7 +208,6 @@
 #include <dbDefs.h>         /* for PVNAME_STRINGSZ */
 #include <epicsTypes.h>     /* for MAX_STRING_SIZE */
 #include <epicsStdio.h>		/* for epicsSnprintf() */
-#include <shareLib.h>       /* for READONLY */
 
 #define MAX(a,b) ((a)>(b)?(a):(b))
 #define MIN(a,b) ((a)<(b)?(a):(b))
@@ -1850,7 +1849,7 @@ LOCAL void extraValCallback(struct event_handler_args eha)
 	PV_NODE * pnode = eha.usr;
 	long type = eha.type;
 	long count = eha.count;
-	READONLY DBR_VAL * pval = eha.dbr;
+	const DBR_VAL * pval = eha.dbr;
 	char *string;
 
 	size_t size=0;
@@ -1897,7 +1896,7 @@ LOCAL void extraValCallback(struct event_handler_args eha)
 LOCAL void extraDescCallback(struct event_handler_args eha)
 {
 	PV_NODE * pnode = eha.usr;
-	READONLY DBR_VAL * pval = eha.dbr;
+	const DBR_VAL * pval = eha.dbr;
 
 	epicsMutexLock(pnode->lock);
 


### PR DESCRIPTION
synApps R6-2-1 (the latest release as of 2023-11-30) includes sscan R2-11-4 (not the latest release as of 2023-11-30), which fails to build against EPICS Base 7.0.7 due to sscan's use of the READONLY macro:

```
../saveData_writeXDR.c:1841:2: error: use of undeclared identifier 'READONLY'
        READONLY DBR_VAL * pval = eha.dbr;
        ^
```

Andrew Johnson suggests in

  https://epics.anl.gov/tech-talk/2023/msg01849.php

that the READONLY macro was likely being defined as a side effect with earlier versions of EPICS Base because most EPICS Base header files used to include shareLib.h, which defines READONLY.  In EPICS Base now, though, Andrew says that the shareLib.h header file is no longer being included by most of the EPICS Base header files, and so it's likely that this is why sscan R2-11-4 no longer builds.

Andrew recommends replacing READONLY with const now that all the compilers supported by EPICS Base support the const keyword, so do just that.

Lastly, this particular build failure was likely fixed in commit

  420274ca2e4331e92119bd0524d0bcd7ffdd9f93

which adds a shareLib.h include to saveData_writeXDR.c.  However, it didn't add an include to saveData.c, so that file is likely still ending up with READONLY defined as a side effect.  Given this and Andrew's comments, it's better to replace READONLY with const.