### PR TITLE
Adjusting string sizing for longer path names

### DIFF
--- a/sscanApp/Db/saveData.db
+++ b/sscanApp/Db/saveData.db
@@ -54,10 +54,9 @@ record(lso, "$(P)saveData_baseName") {
   field(SIZV, "256")
 }
 
-record(waveform, "$(P)saveData_fullPathName") {
+record(lso, "$(P)saveData_fullPathName") {
   field(DTYP, "Soft Channel")
-  field(NELM, "512")
-  field(FTVL, "CHAR")
+  field(SIZV, "512")
 }
 
 record(longout, "$(P)saveData_maxAllowedRetries") {

--- a/sscanApp/Db/saveData.db
+++ b/sscanApp/Db/saveData.db
@@ -30,30 +30,28 @@ record(stringout, "$(P)saveData_comment2") {
   field(DTYP, "Soft Channel")
 }
 
-record(stringout, "$(P)saveData_fileName") {
+record(lso, "$(P)saveData_fileName") {
   field(DTYP, "Soft Channel")
+  field(SIZV, "256")
 }
 
-record(waveform, "$(P)saveData_fileSystem") {
+record(lso, "$(P)saveData_fileSystem") {
   field(DTYP, "Soft Channel")
-  field(NELM, "256")
-  field(FTVL, "CHAR")
+  field(SIZV, "256")
 }
 
 record(stringout, "$(P)saveData_message") {
   field(DTYP, "Soft Channel")
 }
 
-record(waveform, "$(P)saveData_subDir") {
+record(lso, "$(P)saveData_subDir") {
   field(DTYP, "Soft Channel")
-  field(NELM, "256")
-  field(FTVL, "CHAR")
+  field(SIZV, "256")
 }
 
-record(waveform, "$(P)saveData_baseName") {
+record(lso, "$(P)saveData_baseName") {
   field(DTYP, "Soft Channel")
-  field(NELM, "256")
-  field(FTVL, "CHAR")
+  field(SIZV, "256")
 }
 
 record(waveform, "$(P)saveData_fullPathName") {

--- a/sscanApp/Db/saveData.db
+++ b/sscanApp/Db/saveData.db
@@ -34,25 +34,31 @@ record(stringout, "$(P)saveData_fileName") {
   field(DTYP, "Soft Channel")
 }
 
-record(stringout, "$(P)saveData_fileSystem") {
+record(waveform, "$(P)saveData_fileSystem") {
   field(DTYP, "Soft Channel")
+  field(NELM, "256")
+  field(FTVL, "CHAR")
 }
 
 record(stringout, "$(P)saveData_message") {
   field(DTYP, "Soft Channel")
 }
 
-record(stringout, "$(P)saveData_subDir") {
+record(waveform, "$(P)saveData_subDir") {
   field(DTYP, "Soft Channel")
+  field(NELM, "256")
+  field(FTVL, "CHAR")
 }
 
-record(stringout, "$(P)saveData_baseName") {
+record(waveform, "$(P)saveData_baseName") {
   field(DTYP, "Soft Channel")
+  field(NELM, "256")
+  field(FTVL, "CHAR")
 }
 
 record(waveform, "$(P)saveData_fullPathName") {
   field(DTYP, "Soft Channel")
-  field(NELM, "100")
+  field(NELM, "512")
   field(FTVL, "CHAR")
 }
 

--- a/sscanApp/Db/saveData_settings.req
+++ b/sscanApp/Db/saveData_settings.req
@@ -1,6 +1,6 @@
-$(P)saveData_fileSystem
-$(P)saveData_subDir
-$(P)saveData_baseName
+$(P)saveData_fileSystem.$
+$(P)saveData_subDir.$
+$(P)saveData_baseName.$
 $(P)saveData_scanNumber
 $(P)saveData_realTime1D
 $(P)saveData_maxAllowedRetries

--- a/sscanApp/op/adl/scan_saveData.adl
+++ b/sscanApp/op/adl/scan_saveData.adl
@@ -1,7 +1,7 @@
 
 file {
-	name="/home/oxygen4/MOONEY/epics/synAppsSVN/support/sscan/sscanApp/op/adl/scan_saveData.adl"
-	version=030107
+	name="/home/beams1/KLANG/Documents/Projects/Repository/git/sscan/sscanApp/op/adl/scan_saveData.adl"
+	version=030111
 }
 display {
 	object {
@@ -107,7 +107,7 @@ text {
 		height=20
 	}
 	control {
-		chan="$(P)saveData_fileSystem"
+		chan="$(P)saveData_fileSystem.$"
 		clr=14
 		bclr=51
 	}
@@ -238,58 +238,47 @@ text {
 	}
 	textix="Example: //"
 }
-composite {
+text {
 	object {
 		x=10
+		y=63
+		width=80
+		height=14
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Subdirectory"
+}
+"text entry" {
+	object {
+		x=100
 		y=60
-		width=380
+		width=260
 		height=20
 	}
-	"composite name"=""
-	children {
-		text {
-			object {
-				x=10
-				y=63
-				width=80
-				height=14
-			}
-			"basic attribute" {
-				clr=14
-			}
-			textix="Subdirectory"
-		}
-		"text entry" {
-			object {
-				x=100
-				y=60
-				width=260
-				height=20
-			}
-			control {
-				chan="$(P)saveData_subDir"
-				clr=14
-				bclr=51
-			}
-			format="string"
-			limits {
-			}
-		}
-		"text entry" {
-			object {
-				x=370
-				y=60
-				width=20
-				height=20
-			}
-			control {
-				chan="$(P)saveData_subDir.DISP"
-				clr=14
-				bclr=51
-			}
-			limits {
-			}
-		}
+	control {
+		chan="$(P)saveData_subDir.$"
+		clr=14
+		bclr=51
+	}
+	format="string"
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=370
+		y=60
+		width=20
+		height=20
+	}
+	control {
+		chan="$(P)saveData_subDir.DISP"
+		clr=14
+		bclr=51
+	}
+	limits {
 	}
 }
 text {
@@ -312,7 +301,7 @@ text {
 		height=20
 	}
 	control {
-		chan="$(P)saveData_baseName"
+		chan="$(P)saveData_baseName.$"
 		clr=14
 		bclr=51
 	}
@@ -746,74 +735,63 @@ composite {
 		}
 	}
 }
-composite {
+"text update" {
+	object {
+		x=50
+		y=150
+		width=340
+		height=14
+	}
+	monitor {
+		chan="$(P)saveData_fileName.$"
+		clr=53
+		bclr=1
+	}
+	format="string"
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=50
+		y=130
+		width=340
+		height=14
+	}
+	monitor {
+		chan="$(P)saveData_fullPathName"
+		clr=53
+		bclr=1
+	}
+	format="string"
+	limits {
+	}
+}
+text {
 	object {
 		x=10
 		y=130
-		width=380
-		height=34
+		width=40
+		height=14
 	}
-	"composite name"=""
-	children {
-		"text update" {
-			object {
-				x=50
-				y=150
-				width=340
-				height=14
-			}
-			monitor {
-				chan="$(P)saveData_fileName"
-				clr=53
-				bclr=1
-			}
-			format="string"
-			limits {
-			}
-		}
-		"text update" {
-			object {
-				x=50
-				y=130
-				width=340
-				height=14
-			}
-			monitor {
-				chan="$(P)saveData_fullPathName"
-				clr=53
-				bclr=1
-			}
-			format="string"
-			limits {
-			}
-		}
-		text {
-			object {
-				x=10
-				y=130
-				width=40
-				height=14
-			}
-			"basic attribute" {
-				clr=14
-			}
-			textix="PATH:"
-			align="horiz. centered"
-		}
-		text {
-			object {
-				x=10
-				y=150
-				width=40
-				height=14
-			}
-			"basic attribute" {
-				clr=14
-			}
-			textix="NAME:"
-			align="horiz. centered"
-		}
+	"basic attribute" {
+		clr=14
 	}
+	textix="PATH:"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=10
+		y=150
+		width=40
+		height=14
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="NAME:"
+	align="horiz. centered"
 }
 text {
 	object {

--- a/sscanApp/op/adl/scan_saveData.adl
+++ b/sscanApp/op/adl/scan_saveData.adl
@@ -759,7 +759,7 @@ composite {
 		height=14
 	}
 	monitor {
-		chan="$(P)saveData_fullPathName"
+		chan="$(P)saveData_fullPathName.$"
 		clr=53
 		bclr=1
 	}

--- a/sscanApp/op/bob/autoconvert/scan_saveData.bob
+++ b/sscanApp/op/bob/autoconvert/scan_saveData.bob
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--Saved on 2026-02-20 13:06:18 by klang-->
+<!--Saved on 2026-02-20 13:39:35 by klang-->
 <display version="2.0.0">
   <name>scan_saveData</name>
   <x>814</x>
@@ -755,7 +755,7 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #172</name>
-    <pv_name>$(P)saveData_fullPathName</pv_name>
+    <pv_name>$(P)saveData_fullPathName.$</pv_name>
     <x>50</x>
     <y>130</y>
     <width>340</width>

--- a/sscanApp/op/bob/autoconvert/scan_saveData.bob
+++ b/sscanApp/op/bob/autoconvert/scan_saveData.bob
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--Saved on 2026-02-20 13:06:18 by klang-->
 <display version="2.0.0">
   <name>scan_saveData</name>
   <x>814</x>
@@ -29,7 +30,7 @@
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>text entry #9</name>
-    <pv_name>$(P)saveData_fileSystem</pv_name>
+    <pv_name>$(P)saveData_fileSystem.$</pv_name>
     <x>90</x>
     <y>15</y>
     <width>270</width>
@@ -204,59 +205,53 @@
     </foreground_color>
     <auto_size>true</auto_size>
   </widget>
-  <widget type="group" version="2.0.0">
-    <name>composite #44</name>
+  <widget type="label" version="2.0.0">
+    <name>text #44</name>
+    <text>Subdirectory</text>
     <x>10</x>
+    <y>63</y>
+    <width>80</width>
+    <height>14</height>
+    <auto_size>true</auto_size>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>text entry #47</name>
+    <pv_name>$(P)saveData_subDir.$</pv_name>
+    <x>100</x>
     <y>60</y>
-    <width>380</width>
-    <height>20</height>
-    <style>3</style>
-    <transparent>true</transparent>
-    <widget type="label" version="2.0.0">
-      <name>text #47</name>
-      <text>Subdirectory</text>
-      <y>3</y>
-      <width>80</width>
-      <height>14</height>
-      <auto_size>true</auto_size>
-    </widget>
-    <widget type="textentry" version="3.0.0">
-      <name>text entry #50</name>
-      <pv_name>$(P)saveData_subDir</pv_name>
-      <x>90</x>
-      <width>260</width>
-      <font>
-        <font family="Liberation Sans" style="REGULAR" size="16.0">
-        </font>
+    <width>260</width>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
-      <background_color>
-        <color red="115" green="223" blue="255">
-        </color>
-      </background_color>
-      <format>6</format>
-      <show_units>false</show_units>
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-    </widget>
-    <widget type="textentry" version="3.0.0">
-      <name>text entry #54</name>
-      <pv_name>$(P)saveData_subDir.DISP</pv_name>
-      <x>360</x>
-      <width>20</width>
-      <font>
-        <font family="Liberation Sans" style="REGULAR" size="16.0">
-        </font>
+    </font>
+    <background_color>
+      <color red="115" green="223" blue="255">
+      </color>
+    </background_color>
+    <format>6</format>
+    <show_units>false</show_units>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>text entry #51</name>
+    <pv_name>$(P)saveData_subDir.DISP</pv_name>
+    <x>370</x>
+    <y>60</y>
+    <width>20</width>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
       </font>
-      <background_color>
-        <color red="115" green="223" blue="255">
-        </color>
-      </background_color>
-      <format>1</format>
-      <show_units>false</show_units>
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-    </widget>
+    </font>
+    <background_color>
+      <color red="115" green="223" blue="255">
+      </color>
+    </background_color>
+    <format>1</format>
+    <show_units>false</show_units>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #58</name>
+    <name>text #55</name>
     <text>Base Name</text>
     <x>10</x>
     <y>88</y>
@@ -265,8 +260,8 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #61</name>
-    <pv_name>$(P)saveData_baseName</pv_name>
+    <name>text entry #58</name>
+    <pv_name>$(P)saveData_baseName.$</pv_name>
     <x>100</x>
     <y>85</y>
     <width>260</width>
@@ -283,7 +278,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #65</name>
+    <name>text entry #62</name>
     <pv_name>$(P)saveData_baseName.DISP</pv_name>
     <x>370</x>
     <y>85</y>
@@ -301,7 +296,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #69</name>
+    <name>text entry #66</name>
     <pv_name>$(P)saveData_scanNumber</pv_name>
     <x>183</x>
     <y>170</y>
@@ -319,7 +314,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #73</name>
+    <name>text #70</name>
     <text>Next scan number</text>
     <x>15</x>
     <y>170</y>
@@ -331,7 +326,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #76</name>
+    <name>text update #73</name>
     <pv_name>$(P)saveData_status</pv_name>
     <x>130</x>
     <y>195</y>
@@ -352,7 +347,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #80</name>
+    <name>text #77</name>
     <text>Save status</text>
     <x>15</x>
     <y>195</y>
@@ -364,7 +359,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #83</name>
+    <name>menu #80</name>
     <pv_name>$(P)saveData_realTime1D</pv_name>
     <x>250</x>
     <y>236</y>
@@ -381,7 +376,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #86</name>
+    <name>text update #83</name>
     <pv_name>$(P)saveData_message</pv_name>
     <x>10</x>
     <y>215</y>
@@ -404,7 +399,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #90</name>
+    <name>text #87</name>
     <text>Write 1D data at each data point?</text>
     <x>10</x>
     <y>240</y>
@@ -413,7 +408,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #93</name>
+    <name>text #90</name>
     <text>Comments for data file:</text>
     <x>10</x>
     <y>260</y>
@@ -422,7 +417,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #96</name>
+    <name>text entry #93</name>
     <pv_name>$(P)saveData_comment1</pv_name>
     <x>10</x>
     <y>275</y>
@@ -441,7 +436,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #100</name>
+    <name>text entry #97</name>
     <pv_name>$(P)saveData_comment2</pv_name>
     <x>10</x>
     <y>295</y>
@@ -460,7 +455,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="rectangle" version="2.0.0">
-    <name>rectangle #104</name>
+    <name>rectangle #101</name>
     <x>12</x>
     <y>326</y>
     <width>380</width>
@@ -475,7 +470,7 @@
     </background_color>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #107</name>
+    <name>text entry #104</name>
     <pv_name>$(P)saveData_maxAllowedRetries</pv_name>
     <x>167</x>
     <y>349</y>
@@ -493,7 +488,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #111</name>
+    <name>text entry #108</name>
     <pv_name>$(P)saveData_retryWaitInSecs</pv_name>
     <x>167</x>
     <y>369</y>
@@ -511,7 +506,7 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #115</name>
+    <name>text #112</name>
     <text>max per write</text>
     <x>27</x>
     <y>349</y>
@@ -520,7 +515,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #118</name>
+    <name>text #115</name>
     <text>retry wait (s)</text>
     <x>27</x>
     <y>369</y>
@@ -529,7 +524,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #121</name>
+    <name>text #118</name>
     <text>Retries</text>
     <x>17</x>
     <y>329</y>
@@ -541,7 +536,7 @@
     <auto_size>true</auto_size>
   </widget>
   <widget type="group" version="2.0.0">
-    <name>composite #124</name>
+    <name>composite #121</name>
     <x>337</x>
     <y>329</y>
     <width>50</width>
@@ -549,7 +544,7 @@
     <style>3</style>
     <transparent>true</transparent>
     <widget type="textupdate" version="2.0.0">
-      <name>text update #127</name>
+      <name>text update #124</name>
       <pv_name>$(P)saveData_abandonedWrites</pv_name>
       <y>20</y>
       <width>50</width>
@@ -570,7 +565,7 @@
       <border_alarm_sensitive>false</border_alarm_sensitive>
     </widget>
     <widget type="label" version="2.0.0">
-      <name>text #131</name>
+      <name>text #128</name>
       <text>ABANDONED</text>
       <width>50</width>
       <height>10</height>
@@ -581,7 +576,7 @@
       <horizontal_alignment>1</horizontal_alignment>
     </widget>
     <widget type="label" version="2.0.0">
-      <name>text #134</name>
+      <name>text #131</name>
       <text>WRITES</text>
       <y>10</y>
       <width>50</width>
@@ -594,16 +589,11 @@
     </widget>
   </widget>
   <widget type="polyline" version="2.0.0">
-    <name>polyline #137</name>
+    <name>polyline #134</name>
     <x>10</x>
     <y>325</y>
     <width>382</width>
     <height>72</height>
-    <line_width>2</line_width>
-    <line_color>
-      <color red="0" green="0" blue="0">
-      </color>
-    </line_color>
     <points>
       <point x="1.0" y="71.0">
       </point>
@@ -612,18 +602,18 @@
       <point x="381.0" y="1.0">
       </point>
     </points>
+    <line_width>2</line_width>
+    <line_color>
+      <color red="0" green="0" blue="0">
+      </color>
+    </line_color>
   </widget>
   <widget type="polyline" version="2.0.0">
-    <name>polyline #141</name>
+    <name>polyline #138</name>
     <x>11</x>
     <y>325</y>
     <width>382</width>
     <height>72</height>
-    <line_width>2</line_width>
-    <line_color>
-      <color red="255" green="255" blue="255">
-      </color>
-    </line_color>
     <points>
       <point x="381.0" y="1.0">
       </point>
@@ -632,9 +622,14 @@
       <point x="1.0" y="71.0">
       </point>
     </points>
+    <line_width>2</line_width>
+    <line_color>
+      <color red="255" green="255" blue="255">
+      </color>
+    </line_color>
   </widget>
   <widget type="group" version="2.0.0">
-    <name>composite #145</name>
+    <name>composite #142</name>
     <x>262</x>
     <y>329</y>
     <width>50</width>
@@ -642,7 +637,7 @@
     <style>3</style>
     <transparent>true</transparent>
     <widget type="textupdate" version="2.0.0">
-      <name>text update #148</name>
+      <name>text update #145</name>
       <pv_name>$(P)saveData_totalRetries</pv_name>
       <y>20</y>
       <width>50</width>
@@ -663,7 +658,7 @@
       <border_alarm_sensitive>false</border_alarm_sensitive>
     </widget>
     <widget type="label" version="2.0.0">
-      <name>text #152</name>
+      <name>text #149</name>
       <text>SINCE</text>
       <width>50</width>
       <height>10</height>
@@ -674,7 +669,7 @@
       <horizontal_alignment>1</horizontal_alignment>
     </widget>
     <widget type="label" version="2.0.0">
-      <name>text #155</name>
+      <name>text #152</name>
       <text>BOOT</text>
       <y>10</y>
       <width>50</width>
@@ -687,7 +682,7 @@
     </widget>
   </widget>
   <widget type="group" version="2.0.0">
-    <name>composite #158</name>
+    <name>composite #155</name>
     <x>212</x>
     <y>329</y>
     <width>40</width>
@@ -695,7 +690,7 @@
     <style>3</style>
     <transparent>true</transparent>
     <widget type="textupdate" version="2.0.0">
-      <name>text update #161</name>
+      <name>text update #158</name>
       <pv_name>$(P)saveData_currRetries</pv_name>
       <y>20</y>
       <width>40</width>
@@ -716,7 +711,7 @@
       <border_alarm_sensitive>false</border_alarm_sensitive>
     </widget>
     <widget type="label" version="2.0.0">
-      <name>text #165</name>
+      <name>text #162</name>
       <text>CURRENT</text>
       <width>40</width>
       <height>10</height>
@@ -727,7 +722,7 @@
       <horizontal_alignment>1</horizontal_alignment>
     </widget>
     <widget type="label" version="2.0.0">
-      <name>text #168</name>
+      <name>text #165</name>
       <text>WRITE</text>
       <y>10</y>
       <width>40</width>
@@ -739,69 +734,64 @@
       <horizontal_alignment>1</horizontal_alignment>
     </widget>
   </widget>
-  <widget type="group" version="2.0.0">
-    <name>composite #171</name>
-    <x>10</x>
+  <widget type="textupdate" version="2.0.0">
+    <name>text update #168</name>
+    <pv_name>$(P)saveData_fileName.$</pv_name>
+    <x>50</x>
+    <y>150</y>
+    <width>340</width>
+    <height>14</height>
+    <foreground_color>
+      <color red="42" green="99" blue="228">
+      </color>
+    </foreground_color>
+    <background_color>
+      <color red="236" green="236" blue="236">
+      </color>
+    </background_color>
+    <format>6</format>
+    <show_units>false</show_units>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>text update #172</name>
+    <pv_name>$(P)saveData_fullPathName</pv_name>
+    <x>50</x>
     <y>130</y>
-    <width>380</width>
-    <height>34</height>
-    <style>3</style>
-    <transparent>true</transparent>
-    <widget type="textupdate" version="2.0.0">
-      <name>text update #174</name>
-      <pv_name>$(P)saveData_fileName</pv_name>
-      <x>40</x>
-      <y>20</y>
-      <width>340</width>
-      <height>14</height>
-      <foreground_color>
-        <color red="42" green="99" blue="228">
-        </color>
-      </foreground_color>
-      <background_color>
-        <color red="236" green="236" blue="236">
-        </color>
-      </background_color>
-      <format>6</format>
-      <show_units>false</show_units>
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-    </widget>
-    <widget type="textupdate" version="2.0.0">
-      <name>text update #178</name>
-      <pv_name>$(P)saveData_fullPathName</pv_name>
-      <x>40</x>
-      <width>340</width>
-      <height>14</height>
-      <foreground_color>
-        <color red="42" green="99" blue="228">
-        </color>
-      </foreground_color>
-      <background_color>
-        <color red="236" green="236" blue="236">
-        </color>
-      </background_color>
-      <format>6</format>
-      <show_units>false</show_units>
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-    </widget>
-    <widget type="label" version="2.0.0">
-      <name>text #182</name>
-      <text>PATH:</text>
-      <width>40</width>
-      <height>14</height>
-      <horizontal_alignment>1</horizontal_alignment>
-    </widget>
-    <widget type="label" version="2.0.0">
-      <name>text #185</name>
-      <text>NAME:</text>
-      <y>20</y>
-      <width>40</width>
-      <height>14</height>
-      <horizontal_alignment>1</horizontal_alignment>
-    </widget>
+    <width>340</width>
+    <height>14</height>
+    <foreground_color>
+      <color red="42" green="99" blue="228">
+      </color>
+    </foreground_color>
+    <background_color>
+      <color red="236" green="236" blue="236">
+      </color>
+    </background_color>
+    <format>6</format>
+    <show_units>false</show_units>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #188</name>
+    <name>text #176</name>
+    <text>PATH:</text>
+    <x>10</x>
+    <y>130</y>
+    <width>40</width>
+    <height>14</height>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>text #179</name>
+    <text>NAME:</text>
+    <x>10</x>
+    <y>150</y>
+    <width>40</width>
+    <height>14</height>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>text #182</name>
     <text>NOTE: for scanSee, basename must end with '_'</text>
     <x>10</x>
     <y>105</y>

--- a/sscanApp/op/ui/autoconvert/scan_saveData.ui
+++ b/sscanApp/op/ui/autoconvert/scan_saveData.ui
@@ -14,94 +14,7 @@
         <string>
 
 QWidget#centralWidget {background: rgba(200, 200, 200, 255);}
-
-caTable {
-       font: 10pt;
-       background: cornsilk;
-       alternate-background-color: wheat;
-}
-
-caLineEdit {
-     border-radius: 1px;
-     background: lightyellow;
-     color: black;
- }
-
-caTextEntry {
-    color: rgb(127, 0, 63);
-    background-color: cornsilk;
-    selection-color: #0a214c;
-    selection-background-color: wheat;
-    border: 1px groove black;
-    border-radius: 1px;
-    padding: 1px;
-}
-
-caTextEntry:focus {
-    padding: 0px;
-    border: 2px groove darkred;
-    border-radius: 1px;
-}
-
-QPushButton {
-      border-color: #00b;
-      border-radius: 2px;
-      padding: 3px;
-      border-width: 1px;
-
-	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
-						   stop:0   rgba(224, 239, 255, 255),
-						   stop:0.5 rgba(199, 215, 230, 255),
-						   stop:1   rgba(184, 214, 236, 255));
-}
-QPushButton:hover {
-	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
-						stop:0   rgba(201, 226, 255, 255),
-						stop:0.5 rgba(177, 204, 230, 255),
-						stop:1   rgba(163, 205, 236, 255));
-}
-QPushButton:pressed {
-	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
-						stop:0   rgba(174, 219, 255, 255),
-						stop:0.5 rgba(165, 199, 230, 255),
-						stop:1   rgba(134, 188, 236, 255));
-}
-
-QPushButton:disabled {
-	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
-						stop:0   rgba(174, 219, 255, 255),
-						stop:0.5 rgba(165, 199, 230, 255),
-						stop:1   rgba(134, 188, 236, 255));
-}
-
-caChoice {
-      background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                  stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
-                                  stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
-}
-
-caChoice &gt; QPushButton {
-      text-align: left;
-      padding: 1px;
-}
-
-caSlider::groove:horizontal {
-border: 1px solid #bbb;
-background: lightgrey;
-height: 20px;
-border-radius: 4px;
-}
-
-caSlider::handle:horizontal {
-background: red;
-border: 1px solid #777;
-width: 13px;
-margin-top: -2px;
-margin-bottom: -2px;
-border-radius: 2px;
-}
-
-
+QPushButton::menu-indicator {image: url(none.png); width: 0}
 
 </string>
     </property>
@@ -155,7 +68,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)saveData_fileSystem</string>
+                <string>$(P)saveData_fileSystem.$</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -568,153 +481,143 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caFrame" name="caFrame_0">
+        <widget class="caLabel" name="caLabel_10">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Subdirectory</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
             <property name="geometry">
                 <rect>
                     <x>10</x>
-                    <y>60</y>
-                    <width>382</width>
-                    <height>22</height>
+                    <y>63</y>
+                    <width>80</width>
+                    <height>14</height>
                 </rect>
             </property>
-            <widget class="caLabel" name="caLabel_10">
-                <property name="frameShape">
-                    <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="foreground">
-                    <color alpha="255">
-                        <red>0</red>
-                        <green>0</green>
-                        <blue>0</blue>
-                    </color>
-                </property>
-                <property name="background">
-                    <color alpha="0">
-                        <red>0</red>
-                        <green>0</green>
-                        <blue>0</blue>
-                    </color>
-                </property>
-                <property name="text">
-                    <string>Subdirectory</string>
-                </property>
-                <property name="fontScaleMode">
-                    <enum>ESimpleLabel::WidthAndHeight</enum>
-                </property>
-                <property name="geometry">
-                    <rect>
-                        <x>0</x>
-                        <y>3</y>
-                        <width>80</width>
-                        <height>14</height>
-                    </rect>
-                </property>
-                <property name="alignment">
-                    <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-                </property>
-            </widget>
-            <widget class="caTextEntry" name="caTextEntry_2">
-                <property name="geometry">
-                    <rect>
-                        <x>90</x>
-                        <y>0</y>
-                        <width>260</width>
-                        <height>20</height>
-                    </rect>
-                </property>
-                <property name="fontScaleMode">
-                    <enum>caLineEdit::WidthAndHeight</enum>
-                </property>
-                <property name="channel">
-                    <string>$(P)saveData_subDir</string>
-                </property>
-                <property name="foreground">
-                    <color alpha="255">
-                        <red>0</red>
-                        <green>0</green>
-                        <blue>0</blue>
-                    </color>
-                </property>
-                <property name="background">
-                    <color alpha="255">
-                        <red>115</red>
-                        <green>223</green>
-                        <blue>255</blue>
-                    </color>
-                </property>
-                <property name="limitsMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="limitsMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="precisionMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="minValue">
-                    <double>0.0</double>
-                </property>
-                <property name="maxValue">
-                    <double>1.0</double>
-                </property>
-                <property name="colorMode">
-                    <enum>caLineEdit::Static</enum>
-                </property>
-                <property name="formatType">
-                    <enum>string</enum>
-                </property>
-            </widget>
-            <widget class="caTextEntry" name="caTextEntry_3">
-                <property name="geometry">
-                    <rect>
-                        <x>360</x>
-                        <y>0</y>
-                        <width>20</width>
-                        <height>20</height>
-                    </rect>
-                </property>
-                <property name="fontScaleMode">
-                    <enum>caLineEdit::WidthAndHeight</enum>
-                </property>
-                <property name="channel">
-                    <string>$(P)saveData_subDir.DISP</string>
-                </property>
-                <property name="foreground">
-                    <color alpha="255">
-                        <red>0</red>
-                        <green>0</green>
-                        <blue>0</blue>
-                    </color>
-                </property>
-                <property name="background">
-                    <color alpha="255">
-                        <red>115</red>
-                        <green>223</green>
-                        <blue>255</blue>
-                    </color>
-                </property>
-                <property name="limitsMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="limitsMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="precisionMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="minValue">
-                    <double>0.0</double>
-                </property>
-                <property name="maxValue">
-                    <double>1.0</double>
-                </property>
-                <property name="colorMode">
-                    <enum>caLineEdit::Static</enum>
-                </property>
-                <property name="formatType">
-                    <enum>decimal</enum>
-                </property>
-            </widget>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_2">
+            <property name="geometry">
+                <rect>
+                    <x>100</x>
+                    <y>60</y>
+                    <width>260</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)saveData_subDir.$</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>string</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_3">
+            <property name="geometry">
+                <rect>
+                    <x>370</x>
+                    <y>60</y>
+                    <width>20</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)saveData_subDir.DISP</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
         </widget>
         <widget class="caLabel" name="caLabel_11">
             <property name="frameShape">
@@ -765,7 +668,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)saveData_baseName</string>
+                <string>$(P)saveData_baseName.$</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -1532,7 +1435,7 @@ border-radius: 2px;
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caFrame" name="caFrame_1">
+        <widget class="caFrame" name="caFrame_0">
             <property name="geometry">
                 <rect>
                     <x>337</x>
@@ -1701,7 +1604,7 @@ border-radius: 2px;
                 <enum>Solid</enum>
             </property>
             <property name="xyPairs">
-                <string>381,1;</string>
+                <string>1,71;1,1;381,1;</string>
             </property>
         </widget>
         <widget class="caPolyLine" name="caPolyLine_1">
@@ -1737,10 +1640,10 @@ border-radius: 2px;
                 <enum>Solid</enum>
             </property>
             <property name="xyPairs">
-                <string>1,71;</string>
+                <string>381,1;381,71;1,71;</string>
             </property>
         </widget>
-        <widget class="caFrame" name="caFrame_2">
+        <widget class="caFrame" name="caFrame_1">
             <property name="geometry">
                 <rect>
                     <x>262</x>
@@ -1876,7 +1779,7 @@ border-radius: 2px;
                 </property>
             </widget>
         </widget>
-        <widget class="caFrame" name="caFrame_3">
+        <widget class="caFrame" name="caFrame_2">
             <property name="geometry">
                 <rect>
                     <x>212</x>
@@ -2012,195 +1915,185 @@ border-radius: 2px;
                 </property>
             </widget>
         </widget>
-        <widget class="caFrame" name="caFrame_4">
+        <widget class="caLineEdit" name="caLineEdit_5">
+            <property name="geometry">
+                <rect>
+                    <x>50</x>
+                    <y>150</y>
+                    <width>340</width>
+                    <height>14</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)saveData_fileName.$</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>42</red>
+                    <green>99</green>
+                    <blue>228</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>236</red>
+                    <green>236</green>
+                    <blue>236</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="formatType">
+                <enum>string</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLineEdit" name="caLineEdit_6">
+            <property name="geometry">
+                <rect>
+                    <x>50</x>
+                    <y>130</y>
+                    <width>340</width>
+                    <height>14</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)saveData_fullPathName</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>42</red>
+                    <green>99</green>
+                    <blue>228</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>236</red>
+                    <green>236</green>
+                    <blue>236</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="formatType">
+                <enum>string</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLabel" name="caLabel_25">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>PATH:</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignHCenter|Qt::AlignVCenter</set>
+            </property>
             <property name="geometry">
                 <rect>
                     <x>10</x>
                     <y>130</y>
-                    <width>382</width>
-                    <height>36</height>
+                    <width>40</width>
+                    <height>14</height>
                 </rect>
             </property>
-            <widget class="caLineEdit" name="caLineEdit_5">
-                <property name="geometry">
-                    <rect>
-                        <x>40</x>
-                        <y>20</y>
-                        <width>340</width>
-                        <height>14</height>
-                    </rect>
-                </property>
-                <property name="fontScaleMode">
-                    <enum>caLineEdit::WidthAndHeight</enum>
-                </property>
-                <property name="channel">
-                    <string>$(P)saveData_fileName</string>
-                </property>
-                <property name="foreground">
-                    <color alpha="255">
-                        <red>42</red>
-                        <green>99</green>
-                        <blue>228</blue>
-                    </color>
-                </property>
-                <property name="background">
-                    <color alpha="255">
-                        <red>236</red>
-                        <green>236</green>
-                        <blue>236</blue>
-                    </color>
-                </property>
-                <property name="limitsMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="limitsMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="precisionMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="minValue">
-                    <double>0.0</double>
-                </property>
-                <property name="maxValue">
-                    <double>1.0</double>
-                </property>
-                <property name="alignment">
-                    <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-                </property>
-                <property name="formatType">
-                    <enum>string</enum>
-                </property>
-                <property name="colorMode">
-                    <enum>caLineEdit::Static</enum>
-                </property>
-            </widget>
-            <widget class="caLineEdit" name="caLineEdit_6">
-                <property name="geometry">
-                    <rect>
-                        <x>40</x>
-                        <y>0</y>
-                        <width>340</width>
-                        <height>14</height>
-                    </rect>
-                </property>
-                <property name="fontScaleMode">
-                    <enum>caLineEdit::WidthAndHeight</enum>
-                </property>
-                <property name="channel">
-                    <string>$(P)saveData_fullPathName</string>
-                </property>
-                <property name="foreground">
-                    <color alpha="255">
-                        <red>42</red>
-                        <green>99</green>
-                        <blue>228</blue>
-                    </color>
-                </property>
-                <property name="background">
-                    <color alpha="255">
-                        <red>236</red>
-                        <green>236</green>
-                        <blue>236</blue>
-                    </color>
-                </property>
-                <property name="limitsMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="limitsMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="precisionMode">
-                    <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="minValue">
-                    <double>0.0</double>
-                </property>
-                <property name="maxValue">
-                    <double>1.0</double>
-                </property>
-                <property name="alignment">
-                    <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-                </property>
-                <property name="formatType">
-                    <enum>string</enum>
-                </property>
-                <property name="colorMode">
-                    <enum>caLineEdit::Static</enum>
-                </property>
-            </widget>
-            <widget class="caLabel" name="caLabel_25">
-                <property name="frameShape">
-                    <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="foreground">
-                    <color alpha="255">
-                        <red>0</red>
-                        <green>0</green>
-                        <blue>0</blue>
-                    </color>
-                </property>
-                <property name="background">
-                    <color alpha="0">
-                        <red>0</red>
-                        <green>0</green>
-                        <blue>0</blue>
-                    </color>
-                </property>
-                <property name="text">
-                    <string>PATH:</string>
-                </property>
-                <property name="fontScaleMode">
-                    <enum>ESimpleLabel::WidthAndHeight</enum>
-                </property>
-                <property name="alignment">
-                    <set>Qt::AlignAbsolute|Qt::AlignHCenter|Qt::AlignVCenter</set>
-                </property>
-                <property name="geometry">
-                    <rect>
-                        <x>0</x>
-                        <y>0</y>
-                        <width>40</width>
-                        <height>14</height>
-                    </rect>
-                </property>
-            </widget>
-            <widget class="caLabel" name="caLabel_26">
-                <property name="frameShape">
-                    <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="foreground">
-                    <color alpha="255">
-                        <red>0</red>
-                        <green>0</green>
-                        <blue>0</blue>
-                    </color>
-                </property>
-                <property name="background">
-                    <color alpha="0">
-                        <red>0</red>
-                        <green>0</green>
-                        <blue>0</blue>
-                    </color>
-                </property>
-                <property name="text">
-                    <string>NAME:</string>
-                </property>
-                <property name="fontScaleMode">
-                    <enum>ESimpleLabel::WidthAndHeight</enum>
-                </property>
-                <property name="alignment">
-                    <set>Qt::AlignAbsolute|Qt::AlignHCenter|Qt::AlignVCenter</set>
-                </property>
-                <property name="geometry">
-                    <rect>
-                        <x>0</x>
-                        <y>20</y>
-                        <width>40</width>
-                        <height>14</height>
-                    </rect>
-                </property>
-            </widget>
+        </widget>
+        <widget class="caLabel" name="caLabel_26">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>NAME:</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignHCenter|Qt::AlignVCenter</set>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>10</x>
+                    <y>150</y>
+                    <width>40</width>
+                    <height>14</height>
+                </rect>
+            </property>
         </widget>
         <widget class="caLabel" name="caLabel_27">
             <property name="frameShape">
@@ -2249,7 +2142,6 @@ border-radius: 2px;
         <zorder>caLabel_8</zorder>
         <zorder>caLabel_9</zorder>
         <zorder>caLabel_10</zorder>
-        <zorder>caFrame_0</zorder>
         <zorder>caLabel_11</zorder>
         <zorder>caLabel_12</zorder>
         <zorder>caLabel_13</zorder>
@@ -2261,18 +2153,17 @@ border-radius: 2px;
         <zorder>caLabel_18</zorder>
         <zorder>caLabel_19</zorder>
         <zorder>caLabel_20</zorder>
-        <zorder>caFrame_1</zorder>
+        <zorder>caFrame_0</zorder>
         <zorder>caPolyLine_0</zorder>
         <zorder>caPolyLine_1</zorder>
         <zorder>caLabel_21</zorder>
         <zorder>caLabel_22</zorder>
-        <zorder>caFrame_2</zorder>
+        <zorder>caFrame_1</zorder>
         <zorder>caLabel_23</zorder>
         <zorder>caLabel_24</zorder>
-        <zorder>caFrame_3</zorder>
+        <zorder>caFrame_2</zorder>
         <zorder>caLabel_25</zorder>
         <zorder>caLabel_26</zorder>
-        <zorder>caFrame_4</zorder>
         <zorder>caLabel_27</zorder>
         <zorder>caTextEntry_0</zorder>
         <zorder>caTextEntry_1</zorder>

--- a/sscanApp/op/ui/autoconvert/scan_saveData.ui
+++ b/sscanApp/op/ui/autoconvert/scan_saveData.ui
@@ -1982,7 +1982,7 @@ QPushButton::menu-indicator {image: url(none.png); width: 0}
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)saveData_fullPathName</string>
+                <string>$(P)saveData_fullPathName.$</string>
             </property>
             <property name="foreground">
                 <color alpha="255">

--- a/sscanApp/src/saveData_writeXDR.c
+++ b/sscanApp/src/saveData_writeXDR.c
@@ -2123,6 +2123,7 @@ LOCAL int initSaveDataTask()
 		if (req_readMacId(rf, buff1, PVNAME_STRINGSZ)==0) {
 			printf("saveData: fullPathName pv name not defined\n");
 		} else {
+			strncat(buff1, ".$", PVNAME_STRINGSZ - strlen(buff1) - 1);
 			ca_search(buff1, &full_pathname_chid);
 			ca_pend_io(0.5);
 		}

--- a/sscanApp/src/saveData_writeXDR.c
+++ b/sscanApp/src/saveData_writeXDR.c
@@ -2152,6 +2152,9 @@ LOCAL int initSaveDataTask()
 		printf("saveData: fileSystem pv name not defined\n");
 		return -1;
 	}
+	
+	strncat(buff1, ".$", PVNAME_STRINGSZ - strlen(buff1) - 1);
+	
 	if (connectFileSystem(buff1)==-1) {
 		printf("saveData: connectFileSystem(%s) failed \n", buff1);
 		return -1;
@@ -2167,6 +2170,9 @@ LOCAL int initSaveDataTask()
 		printf("saveData: subDir pv name not defined\n");
 		return -1;
 	}
+	
+	strncat(buff1, ".$", PVNAME_STRINGSZ - strlen(buff1) - 1);
+	
 	if (connectSubdir(buff1)==-1) {
 		printf("saveData: connectSubdir(%s) failed \n", buff1);
 		return -1;
@@ -2179,6 +2185,8 @@ LOCAL int initSaveDataTask()
 		if (req_readMacId(rf, buff1, PVNAME_STRINGSZ)==0) {
 			printf("saveData: baseName pv name not defined\n");
 		} else {
+			strncat(buff1, ".$", PVNAME_STRINGSZ - strlen(buff1) - 1);
+		
 			if (connectBasename(buff1)==-1) {
 				printf("saveData: failed to connect to baseName pv\n");
 			}

--- a/sscanApp/src/saveData_writeXDR.c
+++ b/sscanApp/src/saveData_writeXDR.c
@@ -213,7 +213,7 @@
 #define DESC_SIZE 30
 #define EGU_SIZE 16
 #define PREFIX_SIZE PVNAME_STRINGSZ/2
-#define BASENAME_SIZE 20
+#define COMPONENT_STRING_SIZE 256
 
 #include "req_file.h"
 #include "writeXDR.h"
@@ -352,7 +352,7 @@ LOCAL const char  save_data_version[]=SAVE_DATA_VERSION;
 #define HANDSHAKE_BUSY 1
 #define HANDSHAKE_DONE 0
 
-#define FNAMELEN 100
+#define FNAMELEN 512
 typedef struct scan {
 	/*========================= PRIVATE FIELDS ===========================*/
 	short        state;       /* state of the structure                   */
@@ -460,7 +460,7 @@ typedef struct scan {
 /*---------------------- saveDataTask's message queue ------------------*/
 
 #define MAX_MSG    1000 /* max # of messages in saveDataTask's queue    */
-#define MAX_SIZE   80   /* max size in byte of the messages             */
+#define MAX_SIZE   512  /* max size in byte of the messages             */
 
 #define MSG_SCAN_DATA  1  /* save scan                                  */
 #define MSG_SCAN_NPTS  2  /* NPTS changed                               */
@@ -571,7 +571,7 @@ typedef struct string_msg {
 	int  type;
 	epicsTimeStamp time;
 	char* pdest;   /* specified as user arg in ca_create_subscription() call */
-	char  string[MAX_STRING_SIZE];
+	char  string[COMPONENT_STRING_SIZE];
 } STRING_MSG;
 
 #define STRING_SIZE (sizeof(STRING_MSG)<MAX_SIZE? \
@@ -579,7 +579,7 @@ typedef struct string_msg {
 
 #define sendStringMsgWait(t,d,s) { \
 	STRING_MSG msg; \
-	msg.type=t; msg.pdest=(char*)d; strncpy(msg.string, s, MAX_STRING_SIZE); \
+	msg.type=t; msg.pdest=(char*)d; strncpy(msg.string, s, COMPONENT_STRING_SIZE); \
 	epicsTimeGetCurrent(&(msg.time)); \
 	epicsMessageQueueSend(msg_queue, (void *)&msg, \
 	STRING_SIZE); }
@@ -627,9 +627,9 @@ typedef struct pv_node {
 LOCAL char  req_file[40];
 LOCAL char  req_macros[40];
 
-LOCAL char  server_pathname[200];
+LOCAL char  server_pathname[COMPONENT_STRING_SIZE];
 LOCAL char* server_subdir;
-LOCAL char  local_pathname[200];
+LOCAL char  local_pathname[COMPONENT_STRING_SIZE];
 LOCAL char* local_subdir;
 
 #define STATUS_INACTIVE         0
@@ -661,7 +661,7 @@ LOCAL chid  realTime1D_chid;
 LOCAL long  counter;  /* data file counter*/
 LOCAL chid  counter_chid;
 LOCAL char  ioc_prefix[PREFIX_SIZE];
-LOCAL char  scanFile_basename[BASENAME_SIZE] = "";
+LOCAL char  scanFile_basename[COMPONENT_STRING_SIZE] = "";
 
 /* file-write retries */
 LOCAL chid  maxAllowedRetries_chid;
@@ -756,7 +756,7 @@ LOCAL int checkRWpermission(char* path) {
 	/* Quick and dirty way to check for R/W permission */
 	int  file;
 	char tmpfile[100];
-
+	
 	strncpy(tmpfile, path, 100);
 	strncat(tmpfile, "/rix_", 100-strlen(tmpfile));
 
@@ -815,8 +815,9 @@ void saveData_Init(char* fname, char* macros)
 			epicsThreadSuspendSelf();
 		}
 	}
-    else
+    else {
         printf("saveData already initialized\n");
+	}
     
 	return;
 }
@@ -1670,17 +1671,17 @@ LOCAL void descMonitor(struct event_handler_args eha)
 
 LOCAL void fileSystemMonitor(struct event_handler_args eha)
 {
-	sendStringMsgWait(MSG_FILE_SYSTEM, NULL, eha.dbr);
+	sendStringMsgWait(MSG_FILE_SYSTEM, NULL, (const char*) eha.dbr);
 }
 
 LOCAL void fileSubdirMonitor(struct event_handler_args eha)
 {
-	sendStringMsgWait(MSG_FILE_SUBDIR, NULL, eha.dbr);
+	sendStringMsgWait(MSG_FILE_SUBDIR, NULL, (const char*) eha.dbr);
 }
 
 LOCAL void fileBasenameMonitor(struct event_handler_args eha)
-{
-	sendStringMsgWait(MSG_FILE_BASENAME, NULL, eha.dbr);
+{	
+	sendStringMsgWait(MSG_FILE_BASENAME, NULL, (const char*) eha.dbr);
 }
 
 LOCAL void realTime1DMonitor(struct event_handler_args eha)
@@ -1708,14 +1709,16 @@ LOCAL int connectFileSystem(char* fs)
 
 	epicsSnprintf(fs_disp, 80, "%s.DISP", fs);
 
-	ca_search(fs, &file_system_chid);
-	ca_search(fs_disp, &file_system_disp_chid);
+	ca_create_channel(fs, NULL, NULL, 0, &file_system_chid);
+	//ca_search(fs_disp, &file_system_disp_chid);
 	if (ca_pend_io(0.5)!=ECA_NORMAL) {
 		printf("saveData: Unable to connect %s\nsaveDataTask not initialized\n", fs);
 		return -1;
 	} else {
-		if (ca_add_event(DBR_STRING, file_system_chid, 
-				fileSystemMonitor, NULL, NULL)!=ECA_NORMAL) {
+		evid id;
+	
+		if (ca_create_subscription(DBR_CHAR, COMPONENT_STRING_SIZE, file_system_chid, DBE_VALUE,
+				fileSystemMonitor, NULL, &id)!=ECA_NORMAL) {
 			printf("saveData: Can't monitor %s\nsaveDataTask not initialized\n", fs);
 			ca_clear_channel(file_system_chid);
 			return -1;
@@ -1729,14 +1732,17 @@ LOCAL int connectSubdir(char* sd)
 	char sd_disp[80];
 
 	epicsSnprintf(sd_disp, 80, "%s.DISP", sd);
-	ca_search(sd, &file_subdir_chid);
-	ca_search(sd_disp, &file_subdir_disp_chid);
+	
+	ca_create_channel(sd, NULL, NULL, 0, &file_subdir_chid);
+	//ca_search(sd_disp, &file_subdir_disp_chid);
 	if (ca_pend_io(0.5)!=ECA_NORMAL) {
 		printf("saveData: Unable to connect %s\nsaveDataTask not initialized\n", sd);
 		return -1;
 	} else {
-		if (ca_add_event(DBR_STRING, file_subdir_chid, 
-				fileSubdirMonitor, NULL, NULL)!=ECA_NORMAL) {
+		evid id;
+	
+		if (ca_create_subscription(DBR_CHAR, COMPONENT_STRING_SIZE, file_subdir_chid, DBE_VALUE,
+				fileSubdirMonitor, NULL, &id)!=ECA_NORMAL) {
 			printf("saveData: Can't monitor %s\nsaveDataTask not initialized\n", sd);
 			ca_clear_channel(file_subdir_chid);
 			return -1;
@@ -1750,15 +1756,17 @@ LOCAL int connectBasename(char* bn)
 	char bn_disp[80];
 
 	epicsSnprintf(bn_disp, 80, "%s.DISP", bn);
-	ca_search(bn, &file_basename_chid);
-	ca_search(bn_disp, &file_basename_disp_chid);
+	ca_create_channel(bn, NULL, NULL, 0, &file_basename_chid);
+	//ca_search(bn_disp, &file_basename_disp_chid);
 	if (ca_pend_io(0.5)!=ECA_NORMAL) {
 		printf("saveData: Unable to connect %s\n", bn);
 		file_basename_chid = NULL;
 		return 0;
 	} else {
-		if (ca_add_event(DBR_STRING, file_basename_chid, 
-				fileBasenameMonitor, NULL, NULL)!=ECA_NORMAL) {
+		evid id;
+	
+		if (ca_create_subscription(DBR_CHAR, COMPONENT_STRING_SIZE, file_basename_chid, DBE_VALUE,
+				fileBasenameMonitor, NULL, &id)!=ECA_NORMAL) {
 			printf("saveData: Can't monitor %s\n", bn);
 			ca_clear_channel(file_basename_chid);
 			file_basename_disp_chid = NULL;
@@ -2045,7 +2053,7 @@ LOCAL int initSaveDataTask()
 
 	server_pathname[0]= '\0';
 	server_subdir= server_pathname;
-	strncpy(local_pathname, "/data/", 200);
+	strncpy(local_pathname, "/data/", COMPONENT_STRING_SIZE);
 	local_subdir= &local_pathname[strlen(local_pathname)];
 
 	rf= req_open_file(req_file, req_macros);
@@ -2358,6 +2366,7 @@ LOCAL int writeScanRecInProgress(SCAN *pscan, epicsTimeStamp stamp, int isRetry)
 	/* Attempt to open data file */
 	Debug1(3, "saveData:writeScanRecInProgress: Opening file '%s'\n", pscan->ffname);
 	epicsTimeGetCurrent(&openTime);
+	
 	fd = fopen(pscan->ffname, pscan->first_scan ? "wb+" : "rb+");
 
 	if ((fd==NULL) || (fileStatus(pscan->ffname) == ERROR)) {
@@ -2918,7 +2927,7 @@ LOCAL void proc_scan_data(SCAN_TS_SHORT_MSG* pmsg)
 			}
 			/* Make file name */
 			if (scanFile_basename[0] == '\0') {
-				strncpy(scanFile_basename, ioc_prefix, BASENAME_SIZE);
+				strncpy(scanFile_basename, ioc_prefix, COMPONENT_STRING_SIZE);
 			}
 			epicsSnprintf(pscan->fname, FNAMELEN, "%s%.4d.mda", scanFile_basename, (int)pscan->counter);
 #ifdef vxWorks
@@ -3560,7 +3569,7 @@ LOCAL void remount_file_system(char* filesystem)
 #ifdef vxWorks
 	nfsUnmount("/data");
 #endif
-
+	
 	file_system_state= FS_NOT_MOUNTED;
 	save_status= STATUS_ACTIVE_FS_ERROR;
 
@@ -3580,6 +3589,7 @@ LOCAL void remount_file_system(char* filesystem)
 		/* extract the host name */
 		int i = 0;
 		cout= hostname;
+		
 		while ((*filesystem!='\0') && (*filesystem!='/') && i<40) {
 			*(cout++)= *(filesystem++);
 			i++;
@@ -3611,8 +3621,8 @@ LOCAL void remount_file_system(char* filesystem)
 #endif
 
 	if (file_system_state == FS_MOUNTED) {
-		strncpy(server_pathname, filesystem, 200);
-		strncat(server_pathname, "/", 200-strlen(server_pathname));
+		strncpy(server_pathname, filesystem, COMPONENT_STRING_SIZE);
+		strncat(server_pathname, "/", COMPONENT_STRING_SIZE-strlen(server_pathname));
 		server_subdir= &server_pathname[strlen(server_pathname)];  
 
 		if (checkRWpermission(path)!=OK) {
@@ -3711,8 +3721,8 @@ LOCAL void proc_file_subdir(STRING_MSG* pmsg)
 
 LOCAL void proc_file_basename(STRING_MSG* pmsg)
 {
-	strncpy(scanFile_basename, pmsg->string, BASENAME_SIZE-1);
-	scanFile_basename[BASENAME_SIZE-1] = '\0';
+	strncpy(scanFile_basename, pmsg->string, COMPONENT_STRING_SIZE-1);
+	scanFile_basename[COMPONENT_STRING_SIZE-1] = '\0';
 	DebugMsg1(2, "MSG_FILE_BASENAME(%s)\n", pmsg->string);
 }
 


### PR DESCRIPTION
Per #35, updates the fileSystem, subDir, and baseName fields to be able to handle up to 256 characters, rather than the <40 they previously did.

fullPathName is similarly increased to 512 characters.