### PR TITLE
Remove epicsThreadSleepQuantum restriction on positioner, readback, and detector delays

### DIFF
--- a/sscanApp/src/sscanRecord.c
+++ b/sscanApp/src/sscanRecord.c
@@ -1481,17 +1481,23 @@ special(struct dbAddr *paddr, int after)
 			break;
 		case sscanRecordDDLY:
 			if (psscan->ddly < 0.0) psscan->ddly = 0.0;
+#ifdef vxWorks
 			psscan->ddly = NINT(psscan->ddly * ticsPerSecond) / ticsPerSecond;
+#endif
 			POST(&psscan->ddly);
 			break;
 		case sscanRecordPDLY:
 			if (psscan->pdly < 0.0) psscan->pdly = 0.0;
+#ifdef vxWorks
 			psscan->pdly = NINT(psscan->pdly * ticsPerSecond) / ticsPerSecond;
+#endif
 			POST(&psscan->pdly);
 			break;
 		case sscanRecordRDLY:
 			if (psscan->rdly < 0.0) psscan->rdly = 0.0;
+#ifdef vxWorks
 			psscan->rdly = NINT(psscan->rdly * ticsPerSecond) / ticsPerSecond;
+#endif
 			POST(&psscan->pdly);
 			break;
 		case sscanRecordPAUS:


### PR DESCRIPTION
The sscan record currently does not permit position, readback, or detector delays (settling times) less than epicsThreadSleepQuantum.  This makes sense for vxWorks, but not for Linux or Windows where epicsThreadSleepQuantum is actually meaningless.

With this change I was able to use a detector setting time of .001 seconds and collect 1000 points/s with the sscan record.

Note that requesting delays less than epicsThreadSleepQuantum/2 will only work correctly with base 7.0.10 or later.  On earlier version of base the timer will expire immediately for delays shorter than epicsThreadSleepQuantum/2.