### PR TITLE
remove K&R style declaration in writeXDR

### DIFF
--- a/sscanApp/src/writeXDR.h
+++ b/sscanApp/src/writeXDR.h
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <epicsTypes.h>
 
-typedef int (*xdrproc_t)();
+typedef int (*xdrproc_t)(FILE*, char*);
 
 extern int write_XDR_Init();
 extern int writeXDR_char(FILE *fd, char *cp);


### PR DESCRIPTION
Just as 86701bc8cc2cb00c6c7eb03fec9bb7fe894132b0 fixed the K&R declaration in `scanParamRecord.c`, this change fixes the C23 compilation error:

    writeXDR.c:165:24: error: too many arguments to function 'xdr_elem'; expected 0, have 2